### PR TITLE
Change the Content-Type in the JSON and XML requests to be an Accept.

### DIFF
--- a/httptest.go
+++ b/httptest.go
@@ -49,7 +49,7 @@ func (w *handler) JSON(u string, args ...interface{}) *JSON {
 	for key, val := range w.Headers {
 		hs[key] = val
 	}
-	hs["Content-Type"] = "application/json"
+	hs["Accept"] = "application/json"
 	return &JSON{
 		URL:     fmt.Sprintf(u, args...),
 		handler: w,
@@ -62,7 +62,7 @@ func (w *handler) XML(u string, args ...interface{}) *XML {
 	for key, val := range w.Headers {
 		hs[key] = val
 	}
-	hs["Content-Type"] = "application/xml"
+	hs["Accept"] = "application/xml"
 	return &XML{
 		URL:     fmt.Sprintf(u, args...),
 		handler: w,


### PR DESCRIPTION
I would think this is the behavior we would want to test for. The `Content-Type` on the request should be used for parsing the request body. We should be testing that the `Accept` header is used correctly. (Which in the absence of the `Content-Type` header, it is well enough.)

This is very much related to https://github.com/gobuffalo/buffalo/issues/1148