### PR TITLE
preserve RequestURI

### DIFF
--- a/request.go
+++ b/request.go
@@ -59,6 +59,7 @@ func (r *Request) perform(req *http.Request) *Response {
 	for key, value := range r.Headers {
 		req.Header.Set(key, value)
 	}
+	req.RequestURI = r.URL
 	req.Header.Set("Cookie", r.handler.Cookies)
 	r.handler.ServeHTTP(res, req)
 	c := res.HeaderMap["Set-Cookie"]


### PR DESCRIPTION
When `httptest.Request` creates `http.Request` by calling `http.NewRequest` directly, it does not preserve second parameter `url` as `Request.RequestURI`, the unmodified request-target. As a result, if a user's application uses something like `context.Request().RequestURI`, the app works fine with `RequestURI` but testing with httptest will failed since there is no `RequestURI` on the structure.

This PR just added the value manually to present `RequestURI` as the user expected.